### PR TITLE
docs: fix typos in 6.6.3.0 release notes

### DIFF
--- a/src/6.6/6.6.3.0.md
+++ b/src/6.6/6.6.3.0.md
@@ -23,7 +23,7 @@ Besides a list of 40 bug fixes, this minor release contains some cool improvemen
 Entities can now be defined using PHP attributes. This allows a more state-of-the-art and cleaner way to define entities.
 
 * [Changes](https://github.com/shopware/shopware/commit/b0d051bebe78e64a1f889bdb432da953e987b5b1)
-* [Documentation][https://github.com/shopware/docs/pull/1390)
+* [Documentation](https://github.com/shopware/docs/pull/1390)
 
 Here a small example:
 ```php
@@ -87,7 +87,7 @@ Added `shopware.updated` hookable event, containing the old and new shopware ver
 
 The old `sw-datepicker` component will be removed in the next major version. Please use the new `mt-datepicker` component instead.
 
-### AAdd wrapper component for sw-colorpicker
+### Add wrapper component for sw-colorpicker
 
 The old `sw-colorpicker` component will be removed in the next major version. Please use the new `mt-colorpicker` component instead.
 


### PR DESCRIPTION
- Correct markdown link syntax
- Remove duplicate "A" in headline