### PR TITLE
6.6.9.0 fix format error in bug list

### DIFF
--- a/src/6.6/6.6.9.0.md
+++ b/src/6.6/6.6.9.0.md
@@ -79,7 +79,8 @@ Additionally, accessible names for `<iframe>` elements were added, and methods s
 * [NEXT-39513](https://github.com/shopware/shopware/issues/5445) - [Github] feat: removed sizes from the meta apple-touch-icon
 * [NEXT-39512](https://github.com/shopware/shopware/issues/5444) - sw-string-filter: Add types `equalsAny`, `prefix` and `suffix`
 * [NEXT-39495](https://github.com/shopware/shopware/issues/5429) - [Github] Fix / Improve promotion help texts
-* [NEXT-39483](https://github.com/shopware/shopware/issues/5422) - [Github] Reuse product slider stream collect criteria* [NEXT-39462](https://github.com/shopware/shopware/issues/5416) - [Github] Fix administration promotion detail bugs
+* [NEXT-39483](https://github.com/shopware/shopware/issues/5422) - [Github] Reuse product slider stream collect criteria
+* [NEXT-39462](https://github.com/shopware/shopware/issues/5416) - [Github] Fix administration promotion detail bugs
 * [NEXT-39448](https://github.com/shopware/shopware/issues/5408) - Administration not all helpers are exposed
 * [NEXT-39419](https://github.com/shopware/shopware/issues/5387) - [Github] Remove duplicate gad_source from ignored parameter list
 * [NEXT-39418](https://github.com/shopware/shopware/issues/5386) - [Github] NEXT-00000 - Prevent product being loaded in own cross selling product streams


### PR DESCRIPTION
One of the list entries was missing a line break