### PR TITLE
fix: v6.6.9.0 date

### DIFF
--- a/src/6.6/6.6.9.0.md
+++ b/src/6.6/6.6.9.0.md
@@ -2,7 +2,7 @@
 nav:
   title: v6.6.9.0
 meta:
-  date: 2024-12-03
+  date: "2024-12-03"
 ---
 
 # Release notes Shopware 6.6.9.0


### PR DESCRIPTION
This fixes `NaN.NaN.NaN` on the homepage of DevDocs.